### PR TITLE
git-annex.plugin.zsh is required for antigen

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,5 +25,11 @@ and enable it in your `.zshrc`:
 plugins+=(git-annex)
 ```
 
+If you use [antigen][] then you could add the bundle and be done with:
+
+```Shell
+antigen bundle add Schnouki/git-annex-zsh-completion
+```
+
 [git-annex]: http://git-annex.branchable.com/
 [oh-my-zsh]: http://github.com/robbyrussell/oh-my-zsh


### PR DESCRIPTION
antigen/antigen-hs required the presence of a git-annex.plugin.zsh,
even if it's empty