### PR TITLE
Support remote descriptions with spaces and/or colons; fix traceback in __annex_repository

### DIFF
--- a/_git-annex
+++ b/_git-annex
@@ -60,17 +60,17 @@ __annex_repository(){
 
     local -a descriptions
     descriptions=($(git annex info --fast --json 2>/dev/null |
-    python3 -c "
+    python3 -c $'
 import json, re, shlex, sys
 parsed = json.load(sys.stdin)
 descriptions = []
-for repo in (parsed['trusted repositories'] + parsed['semitrusted repositories'] + parsed['untrusted repositories']):
-    desc = repo['description']
-    m = re.match(r'(?:(.+?)\s*)?\[(.+)\]', desc)
+for repo in (parsed["trusted repositories"] + parsed["semitrusted repositories"] + parsed["untrusted repositories"]):
+    desc = repo["description"]
+    m = re.match(r"(?:(.+?)\\s*)?\\[(.+)\\]", desc)
     if m is not None:
-        desc = m.group(2) + ('' if m.group(1) is None else (':' + m.group(1)))
+        desc = m.group(2) + ("" if m.group(1) is None else (":" + m.group(1)))
     descriptions.append(desc)
-print(' '.join(descriptions))"))
+print(" ".join(descriptions))'))
     _describe -t descriptions 'known remotes' descriptions
 
     local -a uuids

--- a/_git-annex
+++ b/_git-annex
@@ -68,8 +68,11 @@ for repo in (parsed.get("trusted repositories", []) + parsed.get("semitrusted re
     m = re.match(r"(?:(.+?)\\s*)?\\[(.+)\\]", desc)
     if m is not None:
         desc = m.group(2)
+        desc = desc.replace(":", r"\\:")
         if m.group(1) is not None:
-            desc += ":" + m.group(1).replace(":", r"\\:")
+            desc += ":" + m.group(1)
+    else:
+        desc = desc.replace(":", r"\\:")
     descriptions.append(desc)
 print(*descriptions, sep="\\0")')"}")
     _describe -t descriptions 'known remotes' descriptions

--- a/_git-annex
+++ b/_git-annex
@@ -27,7 +27,6 @@
 #
 # * 'git annex add' to only complete files not in annex
 # * user defined groups are not detected
-# * remotes with spaces in their description are not handled
 #
 
 local state line context
@@ -59,7 +58,7 @@ __annex_repository(){
     __annex_remotes
 
     local -a descriptions
-    descriptions=($(git annex info --fast --json 2>/dev/null |
+    descriptions=("${(@ps:\0:):-"$(git annex info --fast --json 2>/dev/null |
     python3 -c $'
 import json, re, shlex, sys
 parsed = json.load(sys.stdin)
@@ -70,7 +69,7 @@ for repo in (parsed["trusted repositories"] + parsed["semitrusted repositories"]
     if m is not None:
         desc = m.group(2) + ("" if m.group(1) is None else (":" + m.group(1)))
     descriptions.append(desc)
-print(" ".join(descriptions))'))
+print(*descriptions, sep="\\0")')"}")
     _describe -t descriptions 'known remotes' descriptions
 
     local -a uuids

--- a/_git-annex
+++ b/_git-annex
@@ -86,7 +86,7 @@ for repo in (parsed.get("trusted repositories", []) + parsed.get("semitrusted re
     m = re.match(r"(?:(?P<desc>.+?)\\s*)?\\[(?P<name>.+)\\]", desc)
     if m is not None:
         desc = m.group(1) if m.group(1) is not None else m.group(2)
-    uuids.append("%s:%s" % (repo["uuid"], desc))
+    uuids.append("%s:%s" % (repo["uuid"], desc.replace(":", r"\\:")))
 print(*uuids, sep="\\0")')"}")
     _describe -t uuids uuid uuids
 }

--- a/_git-annex
+++ b/_git-annex
@@ -63,7 +63,7 @@ __annex_repository(){
 import json, re, shlex, sys
 parsed = json.load(sys.stdin)
 descriptions = []
-for repo in (parsed["trusted repositories"] + parsed["semitrusted repositories"] + parsed["untrusted repositories"]):
+for repo in (parsed.get("trusted repositories", []) + parsed.get("semitrusted repositories", []) + parsed.get("untrusted repositories", [])):
     desc = repo["description"]
     m = re.match(r"(?:(.+?)\\s*)?\\[(.+)\\]", desc)
     if m is not None:
@@ -80,7 +80,7 @@ print(*descriptions, sep="\\0")')"}")
 import json, re, sys
 parsed = json.load(sys.stdin)
 uuids = []
-for repo in (parsed['trusted repositories'] + parsed['semitrusted repositories'] + parsed['untrusted repositories']):
+for repo in (parsed.get('trusted repositories', []) + parsed.get('semitrusted repositories', []) + parsed.get('untrusted repositories', [])):
     desc = repo['description']
     m = re.match(r'(?:(?P<desc>.+?)\s*)?\[(?P<name>.+)\]', desc)
     if m is not None:

--- a/_git-annex
+++ b/_git-annex
@@ -76,18 +76,18 @@ print(*descriptions, sep="\\0")')"}")
     _describe -t descriptions 'known remotes' descriptions
 
     local -a uuids
-    uuids=($(git annex info --fast --json 2>/dev/null |
-    python3 -c "
+    uuids=("${(@ps:\0:):-"$(git annex info --fast --json 2>/dev/null |
+    python3 -c $'
 import json, re, sys
 parsed = json.load(sys.stdin)
 uuids = []
-for repo in (parsed.get('trusted repositories', []) + parsed.get('semitrusted repositories', []) + parsed.get('untrusted repositories', [])):
-    desc = repo['description']
-    m = re.match(r'(?:(?P<desc>.+?)\s*)?\[(?P<name>.+)\]', desc)
+for repo in (parsed.get("trusted repositories", []) + parsed.get("semitrusted repositories", []) + parsed.get("untrusted repositories", [])):
+    desc = repo["description"]
+    m = re.match(r"(?:(?P<desc>.+?)\\s*)?\\[(?P<name>.+)\\]", desc)
     if m is not None:
         desc = m.group(1) if m.group(1) is not None else m.group(2)
-    uuids.append('%s:%s' % (repo['uuid'], desc))
-print(' '.join(uuids))"))
+    uuids.append("%s:%s" % (repo["uuid"], desc))
+print(*uuids, sep="\\0")')"}")
     _describe -t uuids uuid uuids
 }
 

--- a/_git-annex
+++ b/_git-annex
@@ -71,9 +71,7 @@ for repo in (parsed.get("trusted repositories", []) + parsed.get("semitrusted re
         desc = desc.replace(":", r"\\:")
         if m.group(1) is not None:
             desc += ":" + m.group(1)
-    else:
-        desc = desc.replace(":", r"\\:")
-    descriptions.append(desc)
+        descriptions.append(desc)
 print(*descriptions, sep="\\0")')"}")
     _describe -t descriptions 'known remotes' descriptions
 

--- a/_git-annex
+++ b/_git-annex
@@ -67,7 +67,9 @@ for repo in (parsed["trusted repositories"] + parsed["semitrusted repositories"]
     desc = repo["description"]
     m = re.match(r"(?:(.+?)\\s*)?\\[(.+)\\]", desc)
     if m is not None:
-        desc = m.group(2) + ("" if m.group(1) is None else (":" + m.group(1)))
+        desc = m.group(2)
+        if m.group(1) is not None:
+            desc += ":" + m.group(1).replace(":", r"\\:")
     descriptions.append(desc)
 print(*descriptions, sep="\\0")')"}")
     _describe -t descriptions 'known remotes' descriptions

--- a/_git-annex
+++ b/_git-annex
@@ -27,6 +27,7 @@
 #
 # * 'git annex add' to only complete files not in annex
 # * user defined groups are not detected
+# * __git_remotes: show only remotes not in __annex_repository (e.g., using 'compadd -F' and ${(q)}/${(b)})
 #
 
 local state line context
@@ -45,9 +46,9 @@ __annex_groups(){
 }
 
 __annex_remotes(){
-    local -a remotes
-    remotes=($(git remote 2>/dev/null))
-    _describe -t remotes 'locally available remotes' remotes
+    local -a expl
+    _description remotes expl 'locally available remotes' 
+    __git_remotes "$expl[@]"
 }
 
 __annex_repository(){


### PR DESCRIPTION
Introduce proper quoting, so descriptions with whitespace now work.  (In fact, descriptions can now contain anything except NUL.)
