### PR TITLE
Fix addunused/dropunused completion.

### DIFF
--- a/_git-annex
+++ b/_git-annex
@@ -264,9 +264,8 @@ case $state in
                    '*:path:_path_files'
         ;;
     (addunused|dropunused)
-        _alternative $common_opts \
-                     'range:Numbers:_guard "[0-9]#" "range of unused objects"' \
-                     'all:all objects:(all)'
+        _arguments : $common_opts \
+                   '*: : _alternative ": :_guard \"[0-9]#(-[0-9]#|)\" \"numeric range of unused objects\"" "all:all objects:(all)"'
         ;;
     (addurl)
         _arguments $common_opts \


### PR DESCRIPTION
$common_opts must be passed to `_arguments`, so call that function.

While here, add support for numeric ranges N-M.

Fixes Schnouki/git-annex-zsh-completion#3.
