### PR TITLE
For 'git annex add' complete only files not already added.

### DIFF
--- a/_git-annex
+++ b/_git-annex
@@ -25,7 +25,6 @@
 # TODO
 # ----
 #
-# * 'git annex add' to only complete files not in annex
 # * user defined groups are not detected
 # * remotes with spaces in their description are not handled
 #
@@ -259,9 +258,10 @@ case $state in
         ;;
 
     (add)
+        # The positional arguments mimic _git-add()'s positional arguments completion
         _arguments $common_opts $matching_opts \
                    '--include-dotfiles[include dotfiles that are not explicitly listed]' \
-                   '*:path:_path_files'
+                   '*:path:__git_ignore_line_inside_arguments __git_other_files ${words[(r)--force]+--ignored}'
         ;;
     (addunused|dropunused)
         _alternative $common_opts \

--- a/_git-annex
+++ b/_git-annex
@@ -259,9 +259,10 @@ case $state in
 
     (add)
         # The positional arguments mimic _git-add()'s positional arguments completion
+        # TODO: the 'modified-files' branch should be intersected with __annex_files, i.e., should exclude modified non-annexed files
         _arguments $common_opts $matching_opts \
                    '--include-dotfiles[include dotfiles that are not explicitly listed]' \
-                   '*:path:__git_ignore_line_inside_arguments __git_other_files ${words[(r)--force]+--ignored}'
+                   '*:path: _alternative -O expl "other-files::__git_ignore_line_inside_arguments __git_other_files ${words[(r)--force]+--ignored}" "modified-files::__git_ignore_line_inside_arguments __git_modified_files"'
         ;;
     (addunused|dropunused)
         _alternative $common_opts \


### PR DESCRIPTION
This completes unversioned files for `git add`.  Ignored files are included iff `--force` has been passed.

The code is based on `_git-add` in the zsh distribution.
